### PR TITLE
Configurer le comportement du backend

### DIFF
--- a/backend/src/main/java/padelFilm/config/CorsConfig.java
+++ b/backend/src/main/java/padelFilm/config/CorsConfig.java
@@ -1,0 +1,22 @@
+package com.padelPlay.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOriginPatterns(
+                        "http://localhost:*",
+                        "http://127.0.0.1:*"
+                )
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}

--- a/backend/src/main/java/padelFilm/config/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/padelFilm/config/JwtAuthenticationFilter.java
@@ -1,0 +1,73 @@
+package com.padelPlay.config;
+
+import com.padelPlay.entity.Administrateur;
+import com.padelPlay.repository.AdministrateurRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtConfig jwtConfig;
+    private final AdministrateurRepository administrateurRepository;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        String authHeader = request.getHeader("Authorization");
+
+        // si pas de token → on laisse passer (les routes publiques sont gérées dans SecurityConfig)
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authHeader.substring(7); // enlève "Bearer "
+
+        if (!jwtConfig.isTokenValid(token)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String email = jwtConfig.extractEmail(token);
+        String role = jwtConfig.extractRole(token);
+
+        // vérifier que l'admin existe toujours en BDD
+        Administrateur admin = administrateurRepository.findByEmail(email).orElse(null);
+        if (admin == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // dire à Spring Security qui est authentifié
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(
+                        email,
+                        null,
+                        List.of(new SimpleGrantedAuthority("ROLE_" + role))
+                );
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        log.debug("Admin {} authenticated with role {}", email, role);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/padelFilm/config/JwtConfig.java
+++ b/backend/src/main/java/padelFilm/config/JwtConfig.java
@@ -1,0 +1,66 @@
+package com.padelPlay.config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtConfig {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private long expiration;
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    // génère un token JWT pour un admin
+    public String generateToken(String email, String role) {
+        return Jwts.builder()
+                .subject(email)
+                .claim("role", role)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    // extrait l'email depuis le token
+    public String extractEmail(String token) {
+        return extractClaims(token).getSubject();
+    }
+
+    // extrait le rôle depuis le token
+    public String extractRole(String token) {
+        return extractClaims(token).get("role", String.class);
+    }
+
+    // vérifie si le token est valide
+    public boolean isTokenValid(String token) {
+        try {
+            extractClaims(token);
+            return true;
+        } catch (Exception e) {
+            log.warn("Invalid JWT token : {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private Claims extractClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/backend/src/main/java/padelFilm/config/SecurityConfig.java
+++ b/backend/src/main/java/padelFilm/config/SecurityConfig.java
@@ -1,0 +1,86 @@
+package com.padelPlay.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(Customizer.withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+
+                        // auth → public
+                        .requestMatchers("/api/auth/**").permitAll()
+
+                        // swagger → public
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html"
+                        ).permitAll()
+
+                        // membres → lecture publique (le frontend membre en a besoin)
+                        .requestMatchers(HttpMethod.GET, "/api/membres/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/membres").permitAll()
+
+                        // matches → lecture publique (voir les matchs publics)
+                        .requestMatchers(HttpMethod.GET, "/api/matches/**").permitAll()
+                        // matches → creation membre (pas de login user, uniquement matricule)
+                        .requestMatchers(HttpMethod.POST, "/api/matches").permitAll()
+
+                        // sites/terrains/jours de fermeture → lecture publique (creation match + affichage)
+                        .requestMatchers(HttpMethod.GET, "/api/sites/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/terrains/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/jours-fermeture/**").permitAll()
+
+                        // réservations → lecture publique
+                        .requestMatchers(HttpMethod.GET, "/api/reservations/**").permitAll()
+
+                        // réservations → création et annulation accessibles aux membres
+                        .requestMatchers(HttpMethod.POST, "/api/reservations").permitAll()
+                        .requestMatchers(HttpMethod.PATCH, "/api/reservations/*/cancel").permitAll()
+
+                        // paiements → accessibles aux membres
+                        .requestMatchers("/api/paiements/**").permitAll()
+
+                        // tout le reste → admin uniquement
+                        .anyRequest().hasAnyRole("GLOBAL", "SITE")
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+            AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}

--- a/backend/src/main/java/padelFilm/config/SwaggerConfig.java
+++ b/backend/src/main/java/padelFilm/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package com.padelPlay.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Padel Backend API")
+                        .description("API REST pour la gestion des terrains de padel")
+                        .version("1.0.0")
+                        .contact(new Contact()
+                                .name("Padel Backend")
+                                .email("admin@padel.com")))
+                .addSecurityItem(new SecurityRequirement().addList("Bearer Auth"))
+                .components(new Components()
+                        .addSecuritySchemes("Bearer Auth", new SecurityScheme()
+                                .name("Bearer Auth")
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("Entrez votre token JWT ici")));
+    }
+}


### PR DESCRIPTION
Configurer le comportement du backend 
📄 SecurityConfig
Rôle
définit les règles de sécurité
Exemple :
routes publiques : /login
routes protégées : /reservations
 Pour

➡️ Protéger les données sensibles

📄 JwtFilter
 Rôle
intercepte chaque requête
vérifie le token utilisateur
 Pour

➡️ Authentifier automatiquement les utilisateurs

📄 CorsConfig
 Rôle
autoriser le frontend à communiquer avec le backend
 Pour

➡️ Sans ça → erreur CORS (bloqué par navigateur)

 SwaggerConfig
 Rôle
documentation API
Pour

➡️ Tester les endpoints facilement